### PR TITLE
🎨 Palette: Dynamic `aria-label` updates on case study accordion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,7 @@
 ## 2024-05-30 - Dynamic ARIA Labels and Screen Reader Support
-
 **Learning:** When creating interactive UI components with custom states (like an accordion or expandable card), simply setting an `aria-expanded` attribute is good, but screen reader users benefit greatly when the label of the trigger button also updates dynamically to reflect the next possible action (e.g. changing from "Expand" to "Collapse"). In addition, providing explicit `aria-label`s on icon-only interactive elements ensures the meaning is strictly conveyed, as `title` attributes alone aren't fully robust across all assistive tech. Also, keyboard accessibility requires providing mechanisms like a "Skip to main content" link to bypass large blocks of repetitive links (like main navigation).
-
 **Action:** Always ensure accordion-like elements toggle the action word in their button's `aria-label`. Always pair icon-only links with explicit `aria-label` attributes alongside `title` for robust fallback. Always consider how keyboard-only users will navigate the top of the page.
+
+## 2026-06-03 - Dynamic ARIA Label Safety
+**Learning:** When dynamically updating `aria-label` attributes based on state, it's critical to first check if an initial `aria-label` actually exists on the element. Unconditionally updating or falling back to an empty string can inadvertently wipe out the accessible name for components that rely on their inner text instead of an `aria-label` attribute.
+**Action:** Always wrap dynamic `aria-label` manipulations in a truthiness check (e.g., `if (currentLabel)`) to prevent null reference errors or accessibility regressions.

--- a/script.js
+++ b/script.js
@@ -137,6 +137,14 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label');
+                if (currentLabel) {
+                    if (isExpanded) {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace('Expand', 'Collapse'));
+                    } else {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace('Collapse', 'Expand'));
+                    }
+                }
             }
         }
 

--- a/scroll.test.js
+++ b/scroll.test.js
@@ -84,10 +84,13 @@ async function runInteractionTests() {
   caseButtons[0].click();
   assert.strictEqual(caseButtons[0].getAttribute('aria-expanded'), 'true');
   assert.strictEqual(caseCards[0].querySelector('.case-body').getAttribute('aria-hidden'), 'false');
+  assert.ok(caseButtons[0].getAttribute('aria-label').startsWith('Collapse'));
 
   caseButtons[1].click();
   assert.strictEqual(caseButtons[0].getAttribute('aria-expanded'), 'false');
+  assert.ok(caseButtons[0].getAttribute('aria-label').startsWith('Expand'));
   assert.strictEqual(caseButtons[1].getAttribute('aria-expanded'), 'true');
+  assert.ok(caseButtons[1].getAttribute('aria-label').startsWith('Collapse'));
 
   const noteCard = document.querySelector('.article-card[data-essay]');
   noteCard.click();


### PR DESCRIPTION
💡 What: Added logic in `script.js` to dynamically toggle the `aria-label` attribute on the case study expand buttons from "Expand" to "Collapse" depending on their state. Also added corresponding tests in `scroll.test.js`.

🎯 Why: To provide a clearer context to screen reader users about the immediate next possible action available to them. 

♿ Accessibility: Ensures that dynamic changes in state are accurately reflected not just via `aria-expanded` but also in the textual description provided by `aria-label`. Checked to prevent wiping out text on elements without existing labels.

---
*PR created automatically by Jules for task [6316136351535042255](https://jules.google.com/task/6316136351535042255) started by @anudeep-peela*