### PR TITLE
🎨 Palette: Restored keyboard focus outlines

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,7 @@
 **Learning:** When creating interactive UI components with custom states (like an accordion or expandable card), simply setting an `aria-expanded` attribute is good, but screen reader users benefit greatly when the label of the trigger button also updates dynamically to reflect the next possible action (e.g. changing from "Expand" to "Collapse"). In addition, providing explicit `aria-label`s on icon-only interactive elements ensures the meaning is strictly conveyed, as `title` attributes alone aren't fully robust across all assistive tech. Also, keyboard accessibility requires providing mechanisms like a "Skip to main content" link to bypass large blocks of repetitive links (like main navigation).
 
 **Action:** Always ensure accordion-like elements toggle the action word in their button's `aria-label`. Always pair icon-only links with explicit `aria-label` attributes alongside `title` for robust fallback. Always consider how keyboard-only users will navigate the top of the page.
+
+## 2026-06-05 - Restoring Keyboard Navigation Focus Outlines
+**Learning:** Suppressing default browser focus rings with `outline: none;` without providing custom focus styles completely breaks keyboard accessibility, leaving users unable to see which element is active.
+**Action:** Always ensure that when removing default outlines, an explicit and highly visible `:focus-visible` outline state (e.g., `outline: 3px solid var(--accent); outline-offset: 4px;`) is added for interactive elements.

--- a/style.css
+++ b/style.css
@@ -109,7 +109,7 @@ a {
 .main-nav a.active {
   background: rgba(255, 255, 255, 0.7);
   color: var(--accent);
-  outline: none;
+
   box-shadow: 0 2px 8px rgba(18, 21, 26, 0.02), inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
@@ -253,7 +253,7 @@ p {
 
 .button:hover,
 .button:focus-visible {
-  outline: none;
+
   transform: translateY(-2px);
 }
 
@@ -1394,4 +1394,12 @@ p {
 
 .skip-to-content:focus {
   top: 0;
+}
+
+.main-nav a:focus-visible,
+.button:focus-visible,
+.case-expand-btn:focus-visible,
+.modal-close-btn:focus-visible {
+  outline: 3px solid var(--accent) !important;
+  outline-offset: 4px;
 }


### PR DESCRIPTION
🎨 Palette: Restored keyboard focus outlines

💡 What: Removed `outline: none;` and added explicit `:focus-visible` outline styles for navigation links, buttons, and other interactive elements.
🎯 Why: Without explicit focus outlines, keyboard users are unable to see which element currently has focus, breaking accessibility.
♿ Accessibility: Ensures that keyboard-only and assistive technology users can reliably navigate the interface visually.

---
*PR created automatically by Jules for task [15992599555227816749](https://jules.google.com/task/15992599555227816749) started by @anudeep-peela*