### PR TITLE
[fix] Make portfolio copy more direct

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Anudeep Peela is a Senior Data Scientist and AI Systems Engineer specializing in production Generative AI, machine learning pipelines, intelligent agents, and scalable MLOps infrastructure.">
+    <meta name="description" content="Anudeep Peela is a Senior Data Scientist and AI Systems Engineer working on applied ML, optimization, GenAI, and data science systems.">
     <meta name="keywords" content="Anudeep Peela, Senior Data Scientist, AI Engineer, Machine Learning Scientist, Generative AI, AI Agents, RAG, MLOps, McKinsey, IIT Bombay">
     <meta name="author" content="Anudeep Peela">
     <meta name="robots" content="index, follow">
@@ -13,12 +13,12 @@
     <link rel="canonical" href="https://anudeep-peela.github.io/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Anudeep Peela | Senior Data Scientist &amp; AI Systems Engineer">
-    <meta property="og:description" content="Production GenAI, intelligent agents, machine learning, and scalable MLOps infrastructure.">
+    <meta property="og:description" content="Applied ML, optimization, GenAI, and data science systems.">
     <meta property="og:url" content="https://anudeep-peela.github.io/">
     <meta property="og:image" content="https://anudeep-peela.github.io/Anudeep_Peela.jpg">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Anudeep Peela | Senior Data Scientist &amp; AI Systems Engineer">
-    <meta name="twitter:description" content="Production GenAI, intelligent agents, machine learning, and scalable MLOps infrastructure.">
+    <meta name="twitter:description" content="Applied ML, optimization, GenAI, and data science systems.">
     <meta name="twitter:image" content="https://anudeep-peela.github.io/Anudeep_Peela.jpg">
     <title>Anudeep Peela | Senior Data Scientist &amp; AI Systems Engineer</title>
     <link rel="stylesheet" href="style.css">
@@ -80,7 +80,7 @@
                 <section class="hero-copy" aria-labelledby="hero-title">
                     <p class="eyebrow">Senior Data Scientist &amp; AI Systems Engineer / McKinsey / IIT Bombay</p>
                     <h1 id="hero-title">Anudeep Peela</h1>
-                    <p class="hero-lede">Building applied ML, optimization, and production AI systems that turn complex operational decisions into measurable outcomes.</p>
+                    <p class="hero-lede">Building applied ML, optimization, and GenAI tools for real operational problems.</p>
                     <div class="hero-meta" aria-label="Profile summary">
                         <span>4+ years at McKinsey</span>
                         <span>Optimization &amp; Production ML</span>
@@ -158,8 +158,8 @@
         <section id="systems" class="section systems-section" aria-labelledby="systems-title">
             <div class="section-heading">
                 <p class="eyebrow">Technical capability</p>
-                <h2 id="systems-title">A systems view of the stack.</h2>
-                <p>Organized the way a tech lead evaluates scope: model quality, data foundations, deployment, monitoring, and business feedback loops.</p>
+                <h2 id="systems-title">Tools I use across the stack.</h2>
+                <p>Core areas I work across: optimization, machine learning, GenAI, data pipelines, and deployment.</p>
             </div>
             <div class="capability-grid">
                 <article><span class="capability-index">01</span><h3>Optimization &amp; OR</h3><p>PuLP, constrained optimization, pricing grids, workforce planning, genetic algorithms, heuristics, KNN benchmarking.</p></article>
@@ -173,7 +173,7 @@
         <section id="work" class="section work-section" aria-labelledby="work-title">
             <div class="section-heading">
                 <p class="eyebrow">Selected case studies</p>
-                <h2 id="work-title">Project stories with technical and business signal.</h2>
+                <h2 id="work-title">Selected projects and what changed.</h2>
             </div>
             <div class="case-grid">
                 <article class="case-card case-card-mobility" id="case-staffing">
@@ -311,15 +311,15 @@
         <section id="writing" class="section writing-section" aria-labelledby="writing-title">
             <div class="section-heading">
                 <p class="eyebrow">Writing &amp; Thinking</p>
-                <h2 id="writing-title">Technical essays &amp; product insights.</h2>
-                <p>Thought leadership at the intersection of production machine learning, software engineering, and business strategy.</p>
+                <h2 id="writing-title">Notes from the work.</h2>
+                <p>Short writing on machine learning, search, optimization, and practical data science trade-offs.</p>
             </div>
             <div class="writing-grid">
                 <!-- Single Focused Article Card -->
                 <article class="article-card featured-single" data-essay="notebook" tabindex="0" role="button" aria-haspopup="dialog">
                     <span class="article-meta">Engineering Notebook</span>
-                    <h3>Sharing Insights on AI Systems &amp; Engineering</h3>
-                    <p>A dedicated space for sharing learnings, architectural notes, and production engineering insights from shipping AI systems at scale. Full essays coming soon.</p>
+                    <h3>Engineering Notebook</h3>
+                    <p>Short notes on systems I have built, trade-offs I have seen, and practical ML patterns. Full essays coming soon.</p>
                     <span class="article-link">Read note <i class="fa-solid fa-arrow-right" aria-hidden="true"></i></span>
                 </article>
             </div>
@@ -364,8 +364,8 @@
             <div class="contact-panel">
                 <div>
                     <p class="eyebrow">Contact</p>
-                    <h2 id="contact-title">Build high-integrity AI with real-world impact.</h2>
-                    <p>Open to conversations around production GenAI, decision systems, applied ML, and senior data science roles.</p>
+                    <h2 id="contact-title">Let&apos;s talk about applied ML and data science work.</h2>
+                    <p>Open to conversations around GenAI, optimization, decision systems, applied ML, and senior data science roles.</p>
                 </div>
                 <div class="contact-actions">
                     <a class="button primary" href="mailto:anudeeppeela9@gmail.com">Email Anudeep</a>
@@ -382,13 +382,13 @@
             <button class="modal-close-btn" aria-label="Close modal"><i class="fa-solid fa-xmark" aria-hidden="true"></i></button>
             <div class="modal-content">
                 <span class="modal-meta">Published May 2026 &bull; 1 min read &bull; Engineering Notebook</span>
-                <h2 id="modal-title-notebook">Sharing Insights on AI Systems &amp; Engineering</h2>
+                <h2 id="modal-title-notebook">Engineering Notebook</h2>
                 
-                <p class="modal-lead">Welcome to my engineering notebook. I believe that shipping robust, production-grade AI systems is as much about sharing knowledge and architectural patterns as it is about writing clean code.</p>
+                <p class="modal-lead">This notebook is where I collect practical notes from data science and ML engineering work.</p>
 
-                <p>In the coming days, I will be publishing a series of technical notes and essays here, focusing on the realities of production-grade AI systems, advanced search architectures, MLOps, and the practical challenges of GenAI at enterprise scale.</p>
+                <p>I plan to write about search systems, optimization, GenAI workflows, MLOps, and the trade-offs that show up when models meet messy real-world data.</p>
                 
-                <p>I look forward to sharing what I have built, the trade-offs encountered along the way, and the engineering maturity required to deliver real-world business impact. Stay tuned!</p>
+                <p>The goal is simple: write down what was useful, what was harder than expected, and what I would reuse on the next project.</p>
             </div>
         </div>
     </div>

--- a/scroll.test.js
+++ b/scroll.test.js
@@ -102,7 +102,7 @@ async function runInteractionTests() {
   assert.strictEqual(modal.getAttribute('aria-hidden'), 'true');
   assert.strictEqual(document.activeElement, noteCard);
 
-  const css = fs.readFileSync('./style.css', 'utf8');
+  const css = fs.readFileSync('./style.css', 'utf8').replace(/\r\n/g, '\n');
   assert.match(css, /flex:\s*0 0 40px/);
   assert.doesNotMatch(css, /order:\s*-1/);
   assert.match(css, /\.main-nav \.nav-social,\s*\n\s*\.main-nav \.nav-cv\s*\{\s*\n\s*display:\s*none/);


### PR DESCRIPTION
## Summary
- Rewrites the portfolio metadata, hero, capability, writing, contact, and notebook modal copy to sound more direct and less buzzword-heavy.
- Removes phrases like "thought leadership," "production-grade," "enterprise scale," and the tech-lead scope sentence.
- Normalizes CSS line endings inside the interaction test so the existing CSS ordering assertion passes on Windows checkouts.

## Why
The site had several lines that read like generic AI consulting copy instead of grounded portfolio writing. This keeps the technical signal and metrics, but makes the voice more plainspoken.

## Validation
- `npm.cmd test`