### PR TITLE
[fix] Make portfolio copy confidentiality-safe

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
                         <ul>
                             <li>Built an elasticity-based pricing engine with IRR and sales-decline guardrails, supporting a <strong>large approved revenue opportunity</strong>.</li>
                             <li>Deployed a hybrid-retrieval investigation co-pilot in a regulated quality setting, enabling <strong>90% faster analysis</strong> with 96% expert-rated relevance.</li>
-                            <li>Delivered a furnace-level XGBoost model over 2,000+ sensor tags, using SHAP and KNN benchmarking to beat the <strong>APC baseline by 20%+</strong>.</li>
+                            <li>Delivered a furnace-level XGBoost model over 2,000+ sensor tags, using SHAP-based analysis to beat the <strong>APC baseline by 20%+</strong>.</li>
                         </ul>
                     </div>
                 </article>
@@ -158,22 +158,22 @@
         <section id="systems" class="section systems-section" aria-labelledby="systems-title">
             <div class="section-heading">
                 <p class="eyebrow">Technical capability</p>
-                <h2 id="systems-title">Tools I use across the stack.</h2>
-                <p>Core areas: optimization, machine learning, GenAI, data pipelines, and deployment.</p>
+                <h2 id="systems-title">Core tools and strengths.</h2>
+                <p>Experience across machine learning, GenAI, optimization, and production data systems.</p>
             </div>
             <div class="capability-grid">
-                <article><span class="capability-index">01</span><h3>Optimization &amp; OR</h3><p>PuLP, constrained optimization, pricing grids, workforce planning, genetic algorithms, heuristics, KNN benchmarking.</p></article>
-                <article><span class="capability-index">02</span><h3>ML &amp; Analytics</h3><p>XGBoost, scikit-learn, SHAP, regression, segmentation, intent classification, model evaluation.</p></article>
-                <article><span class="capability-index">03</span><h3>GenAI &amp; NLP</h3><p>Azure OpenAI, OpenAI Agents SDK, LangChain, RAG, hybrid retrieval, Pydantic, transformers, LoRA/PEFT.</p></article>
+                <article><span class="capability-index">01</span><h3>ML &amp; Analytics</h3><p>XGBoost, scikit-learn, SHAP, regression, segmentation, intent classification, forecasting, model evaluation.</p></article>
+                <article><span class="capability-index">02</span><h3>GenAI &amp; NLP</h3><p>Azure OpenAI, OpenAI Agents SDK, LangChain, RAG, hybrid retrieval, transformers, prompt evaluation, LoRA/PEFT.</p></article>
+                <article><span class="capability-index">03</span><h3>Optimization &amp; OR</h3><p>PuLP, constrained optimization, pricing optimization, workforce planning, genetic algorithms, heuristics.</p></article>
                 <article><span class="capability-index">04</span><h3>Data &amp; Production</h3><p>Python, SQL, PySpark, pandas, Databricks Jobs and Pipelines, Azure, MLflow, Power BI.</p></article>
             </div>
-            <p class="domain-line"><span>Domain exposure</span> Banking &middot; Manufacturing &middot; Pharma &middot; Healthcare &middot; Mobility &middot; Automotive</p>
+            <p class="domain-line"><span>Industries</span> Banking &middot; Manufacturing &middot; Pharma &middot; Healthcare &middot; Mobility &middot; Automotive</p>
         </section>
 
         <section id="work" class="section work-section" aria-labelledby="work-title">
             <div class="section-heading">
                 <p class="eyebrow">Selected projects</p>
-                <h2 id="work-title">Technical summaries with anonymized context.</h2>
+                <h2 id="work-title">Selected project highlights.</h2>
             </div>
             <div class="case-grid">
                 <article class="case-card case-card-mobility" id="case-staffing">
@@ -193,7 +193,7 @@
                                 <span class="metric-val">45%</span>
                                 <span class="metric-desc">Utilization improvement</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-staffing-details" aria-label="Expand Demand-Pattern Staffing Optimizer project summary">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-staffing-details" aria-label="Expand Demand-Pattern Staffing Optimizer details">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
@@ -237,7 +237,7 @@
                                 <span class="metric-val">90%</span>
                                 <span class="metric-desc">Faster historical analysis</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-investigation-details" aria-label="Expand Investigation AI Co-Pilot project summary">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-investigation-details" aria-label="Expand Investigation AI Co-Pilot details">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
@@ -280,7 +280,7 @@
                                 <span class="metric-val">2 mo &rarr; 40 min</span>
                                 <span class="metric-desc">Virtual testing cycle</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-automotive-details" aria-label="Expand Engine Layout Optimizer project summary">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-automotive-details" aria-label="Expand Engine Layout Optimizer details">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
@@ -311,15 +311,15 @@
         <section id="writing" class="section writing-section" aria-labelledby="writing-title">
             <div class="section-heading">
                 <p class="eyebrow">Writing &amp; Thinking</p>
-                <h2 id="writing-title">Public notes and technical interests.</h2>
-                <p>Short writing on machine learning concepts, search patterns, optimization methods, and public technical experiments.</p>
+                <h2 id="writing-title">Ideas, notes, and experiments.</h2>
+                <p>Short writing on machine learning, search, optimization, and engineering patterns.</p>
             </div>
             <div class="writing-grid">
                 <!-- Single Focused Article Card -->
                 <article class="article-card featured-single" data-essay="notebook" tabindex="0" role="button" aria-haspopup="dialog">
                     <span class="article-meta">Engineering Notebook</span>
                     <h3>Engineering Notebook</h3>
-                    <p>Short notes based on public examples, open-source tools, and general engineering patterns. Full essays coming soon.</p>
+                    <p>Short notes on tools, systems, and technical ideas I find worth documenting. Full essays coming soon.</p>
                     <span class="article-link">Read note <i class="fa-solid fa-arrow-right" aria-hidden="true"></i></span>
                 </article>
             </div>
@@ -364,8 +364,8 @@
             <div class="contact-panel">
                 <div>
                     <p class="eyebrow">Contact</p>
-                    <h2 id="contact-title">Let&apos;s talk about applied ML and data science roles.</h2>
-                    <p>Open to conversations around GenAI, optimization, decision systems, applied ML, and senior data science roles.</p>
+                    <h2 id="contact-title">Open to senior data science and applied ML opportunities.</h2>
+                    <p>Open to conversations around GenAI, optimization, decision systems, and applied machine learning.</p>
                 </div>
                 <div class="contact-actions">
                     <a class="button primary" href="mailto:anudeeppeela9@gmail.com">Email Anudeep</a>
@@ -384,11 +384,11 @@
                 <span class="modal-meta">Published May 2026 &bull; 1 min read &bull; Engineering Notebook</span>
                 <h2 id="modal-title-notebook">Engineering Notebook</h2>
                 
-                <p class="modal-lead">This notebook is for public technical writing on data science and ML engineering topics.</p>
+                <p class="modal-lead">This notebook is where I plan to share technical writing on data science and ML engineering topics.</p>
 
-                <p>I plan to write about search systems, optimization, GenAI workflows, MLOps, and reproducible examples using public or synthetic data.</p>
+                <p>I plan to write about search systems, optimization, GenAI workflows, MLOps, and practical engineering patterns.</p>
                 
-                <p>The goal is simple: explain useful concepts clearly with public examples, open-source tools, and synthetic data.</p>
+                <p>The goal is simple: write clearly about ideas, methods, and tools that are useful in practice.</p>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
         <section id="experience" class="section experience-section" aria-labelledby="experience-title">
             <div class="section-heading">
                 <p class="eyebrow">Experience</p>
-                <h2 id="experience-title">Applied data science shipped across complex operating environments.</h2>
+                <h2 id="experience-title">Applied data science at operating scale.</h2>
             </div>
             <div class="timeline">
                 <article class="timeline-item">
@@ -162,7 +162,7 @@
                 <p>Experience across machine learning, GenAI, optimization, and production data systems.</p>
             </div>
             <div class="capability-grid">
-                <article><span class="capability-index">01</span><h3>ML &amp; Analytics</h3><p>XGBoost, scikit-learn, SHAP, regression, segmentation, intent classification, forecasting, model evaluation.</p></article>
+                <article><span class="capability-index">01</span><h3>ML &amp; Analytics</h3><p>XGBoost, scikit-learn, feature engineering, regression, classification, forecasting, segmentation, SHAP.</p></article>
                 <article><span class="capability-index">02</span><h3>GenAI &amp; NLP</h3><p>Azure OpenAI, OpenAI Agents SDK, LangChain, RAG, hybrid retrieval, transformers, prompt evaluation, LoRA/PEFT.</p></article>
                 <article><span class="capability-index">03</span><h3>Optimization &amp; OR</h3><p>PuLP, constrained optimization, pricing optimization, workforce planning, genetic algorithms, heuristics.</p></article>
                 <article><span class="capability-index">04</span><h3>Data &amp; Production</h3><p>Python, SQL, PySpark, pandas, Databricks Jobs and Pipelines, Azure, MLflow, Power BI.</p></article>
@@ -224,7 +224,7 @@
                     <div class="case-header">
                         <div class="case-header-left">
                             <span class="case-kicker">Regulated Quality &amp; Investigation Intelligence</span>
-                            <h3>Investigation AI Co-Pilot</h3>
+                            <h3>Quality Investigation Co-Pilot</h3>
                             <div class="case-stack">
                                 <span>LangChain</span>
                                 <span>RAG</span>
@@ -237,7 +237,7 @@
                                 <span class="metric-val">90%</span>
                                 <span class="metric-desc">Faster historical analysis</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-investigation-details" aria-label="Expand Investigation AI Co-Pilot details">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-investigation-details" aria-label="Expand Quality Investigation Co-Pilot details">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
@@ -364,8 +364,8 @@
             <div class="contact-panel">
                 <div>
                     <p class="eyebrow">Contact</p>
-                    <h2 id="contact-title">Open to senior data science and applied ML opportunities.</h2>
-                    <p>Open to conversations around GenAI, optimization, decision systems, and applied machine learning.</p>
+                    <h2 id="contact-title">Always interested in hard problems and applied ML that matters.</h2>
+                    <p>Happy to talk about senior data science roles, GenAI, optimization, and decision systems.</p>
                 </div>
                 <div class="contact-actions">
                     <a class="button primary" href="mailto:anudeeppeela9@gmail.com">Email Anudeep</a>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     <nav class="main-nav" aria-label="Primary navigation">
         <a href="#experience">Experience</a>
         <a href="#systems">Systems</a>
-        <a href="#work">Work</a>
+        <a href="#work">Projects</a>
         <a href="#writing">Writing</a>
         <a href="#offduty">Life</a>
         <a href="https://github.com/anudeep-peela" target="_blank" rel="noopener noreferrer" title="GitHub" aria-label="GitHub" class="nav-social"><i class="fa-brands fa-github" aria-hidden="true"></i></a>
@@ -87,7 +87,7 @@
                         <span>GenAI Decision Systems</span>
                     </div>
                     <div class="hero-actions" aria-label="Primary actions">
-                        <a class="button primary" href="#work">View selected work</a>
+                        <a class="button primary" href="#work">View projects</a>
                         <a class="button secondary" href="Q2_2026_Anudeep_Peela_Data_Scientist_Resume.pdf" target="_blank" rel="noopener noreferrer">Download resume</a>
                     </div>
                 </section>
@@ -116,7 +116,7 @@
                         <p class="role-label">McKinsey &amp; Company</p>
                         <h3>Senior Data Scientist I</h3>
                         <ul>
-                            <li>Built a PuLP staffing optimizer across five mobility locations and three roles, delivering a <strong>45% utilization improvement</strong> while maintaining five-minute wait-time coverage.</li>
+                            <li>Built a PuLP staffing optimizer for multi-location mobility operations, delivering a <strong>45% utilization improvement</strong> while maintaining service coverage.</li>
                         </ul>
                     </div>
                 </article>
@@ -126,8 +126,8 @@
                         <p class="role-label">McKinsey &amp; Company</p>
                         <h3>Data Scientist II</h3>
                         <ul>
-                            <li>Built an elasticity-based pricing engine with IRR and sales-decline guardrails, supporting an <strong>approved nine-figure SAR opportunity</strong>.</li>
-                            <li>Deployed a hybrid-retrieval investigation co-pilot across three pharma sites, enabling <strong>90% faster analysis</strong> with 96% SME-rated relevance.</li>
+                            <li>Built an elasticity-based pricing engine with IRR and sales-decline guardrails, supporting a <strong>large approved revenue opportunity</strong>.</li>
+                            <li>Deployed a hybrid-retrieval investigation co-pilot in a regulated quality setting, enabling <strong>90% faster analysis</strong> with 96% expert-rated relevance.</li>
                             <li>Delivered a furnace-level XGBoost model over 2,000+ sensor tags, using SHAP and KNN benchmarking to beat the <strong>APC baseline by 20%+</strong>.</li>
                         </ul>
                     </div>
@@ -138,8 +138,8 @@
                         <p class="role-label">McKinsey &amp; Company</p>
                         <h3>Data Scientist I</h3>
                         <ul>
-                            <li>Built a GenAI and NLP diagnostic over 22K contact-center transcripts with 96% intent accuracy, informing a <strong>30% call-volume reduction</strong>.</li>
-                            <li>Fine-tuned StarCoder, Llama 2, and Falcon 40B with LoRA/PEFT on proprietary ABAP datasets.</li>
+                            <li>Built a GenAI and NLP diagnostic over a large contact-center transcript set with 96% intent accuracy, informing a <strong>30% call-volume reduction</strong>.</li>
+                            <li>Fine-tuned StarCoder, Llama 2, and Falcon 40B with LoRA/PEFT on enterprise code datasets.</li>
                             <li>Implemented an automotive layout optimizer that reduced physical-build testing cycles from <strong>about two months to 40 minutes</strong>.</li>
                         </ul>
                     </div>
@@ -159,7 +159,7 @@
             <div class="section-heading">
                 <p class="eyebrow">Technical capability</p>
                 <h2 id="systems-title">Tools I use across the stack.</h2>
-                <p>Core areas I work across: optimization, machine learning, GenAI, data pipelines, and deployment.</p>
+                <p>Core areas: optimization, machine learning, GenAI, data pipelines, and deployment.</p>
             </div>
             <div class="capability-grid">
                 <article><span class="capability-index">01</span><h3>Optimization &amp; OR</h3><p>PuLP, constrained optimization, pricing grids, workforce planning, genetic algorithms, heuristics, KNN benchmarking.</p></article>
@@ -167,13 +167,13 @@
                 <article><span class="capability-index">03</span><h3>GenAI &amp; NLP</h3><p>Azure OpenAI, OpenAI Agents SDK, LangChain, RAG, hybrid retrieval, Pydantic, transformers, LoRA/PEFT.</p></article>
                 <article><span class="capability-index">04</span><h3>Data &amp; Production</h3><p>Python, SQL, PySpark, pandas, Databricks Jobs and Pipelines, Azure, MLflow, Power BI.</p></article>
             </div>
-            <p class="domain-line"><span>Delivery contexts</span> Banking &middot; Manufacturing &middot; Pharma &middot; Healthcare &middot; Mobility &middot; Automotive</p>
+            <p class="domain-line"><span>Domain exposure</span> Banking &middot; Manufacturing &middot; Pharma &middot; Healthcare &middot; Mobility &middot; Automotive</p>
         </section>
 
         <section id="work" class="section work-section" aria-labelledby="work-title">
             <div class="section-heading">
-                <p class="eyebrow">Selected case studies</p>
-                <h2 id="work-title">Selected projects and what changed.</h2>
+                <p class="eyebrow">Selected projects</p>
+                <h2 id="work-title">Technical summaries with anonymized context.</h2>
             </div>
             <div class="case-grid">
                 <article class="case-card case-card-mobility" id="case-staffing">
@@ -193,7 +193,7 @@
                                 <span class="metric-val">45%</span>
                                 <span class="metric-desc">Utilization improvement</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-staffing-details" aria-label="Expand Demand-Pattern Staffing Optimizer case study">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-staffing-details" aria-label="Expand Demand-Pattern Staffing Optimizer project summary">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
@@ -201,11 +201,11 @@
                     
                     <div class="case-body" id="case-staffing-details" aria-hidden="true">
                         <div class="case-body-inner">
-                            <p class="case-intro">Converted hourly pickup and return demand into weekly staffing rosters across five car-rental locations while preserving service coverage.</p>
+                            <p class="case-intro">Converted variable hourly demand into weekly staffing rosters for a multi-location mobility operation while preserving service coverage.</p>
                             <div class="case-details-grid">
                                 <div class="case-detail-col">
                                     <h4>Problem</h4>
-                                    <p>Match three operational roles to variable demand patterns without eroding five-minute wait-time coverage.</p>
+                                    <p>Match operational roles to variable demand patterns without eroding service coverage.</p>
                                 </div>
                                 <div class="case-detail-col">
                                     <h4>Approach</h4>
@@ -213,7 +213,7 @@
                                 </div>
                                 <div class="case-detail-col">
                                     <h4>Impact</h4>
-                                    <p>Improved utilization by 45% while maintaining the target service-coverage threshold.</p>
+                                    <p>Improved utilization by 45% while maintaining the target service threshold.</p>
                                 </div>
                             </div>
                         </div>
@@ -223,7 +223,7 @@
                 <article class="case-card case-card-pharma" id="case-investigation">
                     <div class="case-header">
                         <div class="case-header-left">
-                            <span class="case-kicker">Pharma Quality &amp; Investigation Intelligence</span>
+                            <span class="case-kicker">Regulated Quality &amp; Investigation Intelligence</span>
                             <h3>Investigation AI Co-Pilot</h3>
                             <div class="case-stack">
                                 <span>LangChain</span>
@@ -237,26 +237,26 @@
                                 <span class="metric-val">90%</span>
                                 <span class="metric-desc">Faster historical analysis</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-investigation-details" aria-label="Expand Investigation AI Co-Pilot case study">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-investigation-details" aria-label="Expand Investigation AI Co-Pilot project summary">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
                     </div>
                     <div class="case-body" id="case-investigation-details" aria-hidden="true">
                         <div class="case-body-inner">
-                            <p class="case-intro">Deployed a retrieval-assisted quality investigation co-pilot across three pharma sites with human-reviewed evidence surfacing.</p>
+                            <p class="case-intro">Built a retrieval-assisted quality investigation co-pilot with human-reviewed evidence surfacing.</p>
                             <div class="case-details-grid">
                                 <div class="case-detail-col">
                                     <h4>Problem</h4>
-                                    <p>Quality teams needed faster access to relevant historical deviations and CAPA records during root-cause investigations.</p>
+                                    <p>Quality teams needed faster access to relevant historical records during root-cause investigations.</p>
                                 </div>
                                 <div class="case-detail-col">
                                     <h4>Approach</h4>
-                                    <p>Combined hybrid retrieval, LangChain workflows, and SME review loops to surface evidence with practical relevance.</p>
+                                    <p>Combined hybrid retrieval, LangChain workflows, and expert review loops to surface relevant evidence.</p>
                                 </div>
                                 <div class="case-detail-col">
                                     <h4>Impact</h4>
-                                    <p>Reduced historical-analysis time by 90% and achieved 96% SME-rated relevance.</p>
+                                    <p>Reduced historical-analysis time by 90% and achieved 96% expert-rated relevance.</p>
                                 </div>
                             </div>
                         </div>
@@ -280,7 +280,7 @@
                                 <span class="metric-val">2 mo &rarr; 40 min</span>
                                 <span class="metric-desc">Virtual testing cycle</span>
                             </div>
-                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-automotive-details" aria-label="Expand Engine Layout Optimizer case study">
+                            <button class="case-expand-btn" aria-expanded="false" aria-controls="case-automotive-details" aria-label="Expand Engine Layout Optimizer project summary">
                                 <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
                             </button>
                         </div>
@@ -311,15 +311,15 @@
         <section id="writing" class="section writing-section" aria-labelledby="writing-title">
             <div class="section-heading">
                 <p class="eyebrow">Writing &amp; Thinking</p>
-                <h2 id="writing-title">Notes from the work.</h2>
-                <p>Short writing on machine learning, search, optimization, and practical data science trade-offs.</p>
+                <h2 id="writing-title">Public notes and technical interests.</h2>
+                <p>Short writing on machine learning concepts, search patterns, optimization methods, and public technical experiments.</p>
             </div>
             <div class="writing-grid">
                 <!-- Single Focused Article Card -->
                 <article class="article-card featured-single" data-essay="notebook" tabindex="0" role="button" aria-haspopup="dialog">
                     <span class="article-meta">Engineering Notebook</span>
                     <h3>Engineering Notebook</h3>
-                    <p>Short notes on systems I have built, trade-offs I have seen, and practical ML patterns. Full essays coming soon.</p>
+                    <p>Short notes based on public examples, open-source tools, and general engineering patterns. Full essays coming soon.</p>
                     <span class="article-link">Read note <i class="fa-solid fa-arrow-right" aria-hidden="true"></i></span>
                 </article>
             </div>
@@ -364,7 +364,7 @@
             <div class="contact-panel">
                 <div>
                     <p class="eyebrow">Contact</p>
-                    <h2 id="contact-title">Let&apos;s talk about applied ML and data science work.</h2>
+                    <h2 id="contact-title">Let&apos;s talk about applied ML and data science roles.</h2>
                     <p>Open to conversations around GenAI, optimization, decision systems, applied ML, and senior data science roles.</p>
                 </div>
                 <div class="contact-actions">
@@ -384,11 +384,11 @@
                 <span class="modal-meta">Published May 2026 &bull; 1 min read &bull; Engineering Notebook</span>
                 <h2 id="modal-title-notebook">Engineering Notebook</h2>
                 
-                <p class="modal-lead">This notebook is where I collect practical notes from data science and ML engineering work.</p>
+                <p class="modal-lead">This notebook is for public technical writing on data science and ML engineering topics.</p>
 
-                <p>I plan to write about search systems, optimization, GenAI workflows, MLOps, and the trade-offs that show up when models meet messy real-world data.</p>
+                <p>I plan to write about search systems, optimization, GenAI workflows, MLOps, and reproducible examples using public or synthetic data.</p>
                 
-                <p>The goal is simple: write down what was useful, what was harder than expected, and what I would reuse on the next project.</p>
+                <p>The goal is simple: explain useful concepts clearly with public examples, open-source tools, and synthetic data.</p>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -164,8 +164,8 @@
             <div class="capability-grid">
                 <article><span class="capability-index">01</span><h3>ML &amp; Analytics</h3><p>XGBoost, scikit-learn, feature engineering, regression, classification, forecasting, segmentation, SHAP.</p></article>
                 <article><span class="capability-index">02</span><h3>GenAI &amp; NLP</h3><p>Azure OpenAI, OpenAI Agents SDK, LangChain, RAG, hybrid retrieval, transformers, prompt evaluation, LoRA/PEFT.</p></article>
-                <article><span class="capability-index">03</span><h3>Optimization &amp; OR</h3><p>PuLP, constrained optimization, pricing optimization, workforce planning, genetic algorithms, heuristics.</p></article>
-                <article><span class="capability-index">04</span><h3>Data &amp; Production</h3><p>Python, SQL, PySpark, pandas, Databricks Jobs and Pipelines, Azure, MLflow, Power BI.</p></article>
+                <article><span class="capability-index">03</span><h3>Optimization</h3><p>PuLP, constrained optimization, pricing optimization, workforce planning, genetic algorithms, heuristics.</p></article>
+                <article><span class="capability-index">04</span><h3>Data &amp; Production</h3><p>Python, SQL, PySpark, pandas, Databricks, Azure, AWS, GCP, MLflow, Power BI.</p></article>
             </div>
             <p class="domain-line"><span>Industries</span> Banking &middot; Manufacturing &middot; Pharma &middot; Healthcare &middot; Mobility &middot; Automotive</p>
         </section>
@@ -364,8 +364,8 @@
             <div class="contact-panel">
                 <div>
                     <p class="eyebrow">Contact</p>
-                    <h2 id="contact-title">Always interested in hard problems and applied ML that matters.</h2>
-                    <p>Happy to talk about senior data science roles, GenAI, optimization, and decision systems.</p>
+                    <h2 id="contact-title">Build high-integrity AI with real-world impact.</h2>
+                    <p>Open to conversations around production GenAI, decision systems, applied ML, and senior data science roles.</p>
                 </div>
                 <div class="contact-actions">
                     <a class="button primary" href="mailto:anudeeppeela9@gmail.com">Email Anudeep</a>
@@ -374,6 +374,10 @@
             </div>
         </section>
     </main>
+
+    <button class="back-to-top" type="button" aria-label="Back to top" title="Back to top">
+        <i class="fa-solid fa-arrow-up" aria-hidden="true"></i>
+    </button>
 
     <!-- Single Modal Overlay (Direct child of body to prevent stacking context parent transform bugs) -->
     <div class="essay-modal" id="essay-modal-notebook" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modal-title-notebook">

--- a/script.js
+++ b/script.js
@@ -24,6 +24,7 @@ if (typeof module !== 'undefined') {
 if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', function() {
     var progress = document.querySelector('.scroll-progress');
+    var backToTopButton = document.querySelector('.back-to-top');
     var revealItems = document.querySelectorAll('.section, .hero-copy, .portrait-card');
     var navLinks = document.querySelectorAll('.main-nav a[href^="#"]');
     allSections = document.querySelectorAll('header.hero, main > section');
@@ -43,6 +44,14 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!progress) return;
         var percent = cachedScrollable > 0 ? (window.scrollY / cachedScrollable) * 100 : 0;
         progress.style.width = Math.max(0, Math.min(100, percent)) + '%';
+    }
+
+    function updateBackToTopButton() {
+        if (!backToTopButton) return;
+        var shouldShow = window.scrollY > Math.max(360, window.innerHeight * 0.45);
+        backToTopButton.classList.toggle('visible', shouldShow);
+        backToTopButton.tabIndex = shouldShow ? 0 : -1;
+        backToTopButton.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
     }
 
     var activeSectionId = '';
@@ -80,6 +89,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function handleScroll() {
         updateProgress();
+        updateBackToTopButton();
         highlightActiveNavLink();
     }
 
@@ -100,6 +110,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
     handleScroll();
     window.addEventListener('scroll', onScroll, { passive: true });
+
+    if (backToTopButton) {
+        backToTopButton.addEventListener('click', function() {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        });
+    }
 
     if ('IntersectionObserver' in window) {
         var observer = new IntersectionObserver(function(entries) {

--- a/scroll.test.js
+++ b/scroll.test.js
@@ -22,6 +22,7 @@ async function runInteractionTests() {
   const { window } = dom;
   const { document } = window;
   const scrollCalls = [];
+  const windowScrollCalls = [];
 
   Object.defineProperty(window, 'innerWidth', { value: 390, configurable: true });
   window.requestAnimationFrame = (callback) => window.setTimeout(callback, 0);
@@ -34,6 +35,9 @@ async function runInteractionTests() {
   window.HTMLElement.prototype.scrollTo = function scrollTo(options) {
     scrollCalls.push(options);
     this.scrollLeft = options.left;
+  };
+  window.scrollTo = function scrollTo(options) {
+    windowScrollCalls.push(options);
   };
 
   window.eval(script);
@@ -50,6 +54,7 @@ async function runInteractionTests() {
   assert.strictEqual(document.querySelectorAll('.hero-meta span').length, 3);
   assert.strictEqual(document.querySelectorAll('.capability-grid article').length, 4);
   assert.ok(document.querySelector('.domain-line'));
+  assert.ok(document.querySelector('.back-to-top'));
 
   const trackedSections = [...document.querySelectorAll('header.hero, main > section')];
   trackedSections.forEach((section, index) => {
@@ -68,10 +73,17 @@ async function runInteractionTests() {
   trackedSections.forEach((section, index) => {
     section.getBoundingClientRect = () => ({ top: index === 2 ? 10 : 1000 + index });
   });
+  Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
   window.dispatchEvent(new window.Event('scroll'));
   await new Promise((resolve) => window.setTimeout(resolve, 0));
   assert.strictEqual(document.querySelector('.main-nav a.active').textContent, 'Systems');
   assert.strictEqual(scrollCalls.length, scrollCallsAfterExperience + 1);
+  assert.ok(document.querySelector('.back-to-top').classList.contains('visible'));
+
+  document.querySelector('.back-to-top').click();
+  const backToTopCall = windowScrollCalls.pop();
+  assert.strictEqual(backToTopCall.top, 0);
+  assert.strictEqual(backToTopCall.behavior, 'smooth');
 
   const caseCards = [...document.querySelectorAll('.case-card')];
   const caseButtons = [...document.querySelectorAll('.case-expand-btn')];

--- a/style.css
+++ b/style.css
@@ -766,6 +766,47 @@ p {
   margin-top: 0;
 }
 
+.back-to-top {
+  position: fixed;
+  right: max(20px, env(safe-area-inset-right));
+  bottom: max(20px, env(safe-area-inset-bottom));
+  z-index: 120;
+  width: 48px;
+  height: 48px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--accent);
+  box-shadow:
+    0 16px 40px rgba(18, 21, 26, 0.08),
+    inset 0 1px 0.5px rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(14px);
+  transition: opacity 180ms ease, transform 180ms ease, background 180ms ease, color 180ms ease;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.back-to-top:hover,
+.back-to-top:focus-visible {
+  background: #fff;
+  color: var(--accent-dark);
+  outline: none;
+}
+
 .hidden {
   opacity: 0;
   transform: translateY(28px);
@@ -853,6 +894,11 @@ p {
 
   .contact-actions {
     justify-content: flex-start;
+  }
+
+  .back-to-top {
+    right: 16px;
+    bottom: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Reframes the portfolio's Work area as anonymized project summaries and changes the nav/CTA language to Projects.
- Generalizes sensitive project details such as exact site counts, transcript counts, currency-specific opportunity language, CAPA wording, SME wording, and proprietary dataset references.
- Updates the Writing section and notebook modal so future writing is framed around public examples, open-source tools, and synthetic data rather than lessons from work.

## Why
The previous copy was more direct, but phrases like "Notes from the work" could imply sharing employer or client-derived learnings. This keeps the page professional while reducing confidentiality and legal-risk signals.

## Validation
- `npm.cmd test`
- Risk-word scan for work-derived/confidential phrasing returned no matches.