### PR TITLE
🎨 Palette: Add keyboard focus rings for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,3 @@
-## 2024-05-30 - Dynamic ARIA Labels and Screen Reader Support
-
-**Learning:** When creating interactive UI components with custom states (like an accordion or expandable card), simply setting an `aria-expanded` attribute is good, but screen reader users benefit greatly when the label of the trigger button also updates dynamically to reflect the next possible action (e.g. changing from "Expand" to "Collapse"). In addition, providing explicit `aria-label`s on icon-only interactive elements ensures the meaning is strictly conveyed, as `title` attributes alone aren't fully robust across all assistive tech. Also, keyboard accessibility requires providing mechanisms like a "Skip to main content" link to bypass large blocks of repetitive links (like main navigation).
-
-**Action:** Always ensure accordion-like elements toggle the action word in their button's `aria-label`. Always pair icon-only links with explicit `aria-label` attributes alongside `title` for robust fallback. Always consider how keyboard-only users will navigate the top of the page.
+## 2024-06-06 - Keyboard Navigation Focus States
+**Learning:** Found an accessibility anti-pattern where `outline: none` was used on `:focus-visible` for buttons and navigation links. This completely removes the focus indicator for keyboard users, relying only on background changes which often fail contrast requirements and are hard to spot.
+**Action:** Replaced `outline: none` with explicit, high-contrast focus rings (`outline: 3px solid var(--accent)`) on all interactive elements. Always ensure keyboard focus is visibly distinct from hover states.

--- a/style.css
+++ b/style.css
@@ -105,12 +105,18 @@ a {
 }
 
 .main-nav a:hover,
-.main-nav a:focus-visible,
 .main-nav a.active {
   background: rgba(255, 255, 255, 0.7);
   color: var(--accent);
-  outline: none;
   box-shadow: 0 2px 8px rgba(18, 21, 26, 0.02), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.main-nav a:focus-visible {
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--accent);
+  box-shadow: 0 2px 8px rgba(18, 21, 26, 0.02), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .main-nav a.active {
@@ -251,10 +257,14 @@ p {
   color: var(--ink);
 }
 
-.button:hover,
-.button:focus-visible {
-  outline: none;
+.button:hover {
   transform: translateY(-2px);
+}
+
+.button:focus-visible {
+  transform: translateY(-2px);
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .button.primary:hover,
@@ -654,6 +664,11 @@ p {
   background: rgba(16, 42, 194, 0.1);
 }
 
+.case-expand-btn:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
 .case-card.expanded .case-expand-btn {
   transform: rotate(180deg);
   background: var(--accent);
@@ -800,11 +815,16 @@ p {
   transform: translateY(0);
 }
 
-.back-to-top:hover,
+.back-to-top:hover {
+  background: #fff;
+  color: var(--accent-dark);
+}
+
 .back-to-top:focus-visible {
   background: #fff;
   color: var(--accent-dark);
-  outline: none;
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .hidden {
@@ -1275,6 +1295,11 @@ p {
   background: rgba(18, 21, 26, 0.08);
   color: var(--accent);
   transform: scale(1.05);
+}
+
+.modal-close-btn:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .modal-close-btn:active {


### PR DESCRIPTION
💡 **What:** Replaced `outline: none` on `:focus-visible` with explicit, high-contrast focus rings (`outline: 3px solid var(--accent); outline-offset: 4px;`) for navigation links, buttons, expand buttons, modal close buttons, and back-to-top buttons.
🎯 **Why:** Improve keyboard accessibility for users navigating the site with a keyboard, providing clear visual feedback when elements receive focus.
♿ **Accessibility:** Fixes a critical accessibility anti-pattern where focus rings were hidden. Keyboard navigation is now visible and clear.

---
*PR created automatically by Jules for task [14512310431611984040](https://jules.google.com/task/14512310431611984040) started by @anudeep-peela*