### PR TITLE
🎨 Palette: Improve accessibility focus states and dynamic ARIA labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,6 +156,14 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label');
+                if (currentLabel) {
+                    if (isExpanded) {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace('Expand', 'Collapse'));
+                    } else {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace('Collapse', 'Expand'));
+                    }
+                }
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -109,7 +109,6 @@ a {
 .main-nav a.active {
   background: rgba(255, 255, 255, 0.7);
   color: var(--accent);
-  outline: none;
   box-shadow: 0 2px 8px rgba(18, 21, 26, 0.02), inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
@@ -253,7 +252,6 @@ p {
 
 .button:hover,
 .button:focus-visible {
-  outline: none;
   transform: translateY(-2px);
 }
 
@@ -963,7 +961,6 @@ p {
 .back-to-top:focus-visible {
   background: #fff;
   color: var(--accent-dark);
-  outline: none;
 }
 
 .hidden {
@@ -1489,7 +1486,12 @@ p {
 
 /* Accessibility Focus States */
 .case-card:focus-visible,
-.article-card:focus-visible {
+.article-card:focus-visible,
+.button:focus-visible,
+.case-expand-btn:focus-visible,
+.modal-close-btn:focus-visible,
+.back-to-top:focus-visible,
+.main-nav a:focus-visible {
   outline: 3px solid var(--accent);
   outline-offset: 4px;
 }


### PR DESCRIPTION
💡 **What:** 
- Updated `script.js` to dynamically toggle the `aria-label` of accordion expansion buttons between "Expand [details]" and "Collapse [details]".
- Updated `style.css` to replace instances of `outline: none;` on `:focus-visible` with a standard, highly visible focus ring matching the existing `.case-card` focus style.

🎯 **Why:** 
- To provide better context to screen reader users interacting with the accordions.
- To ensure keyboard navigators can clearly see which element currently has focus, replacing an accessibility anti-pattern.

♿ **Accessibility:** 
- Improved screen reader context on dynamic elements.
- Greatly improved keyboard navigation visibility across buttons, nav links, modals, and accordions.

---
*PR created automatically by Jules for task [6158310767111411938](https://jules.google.com/task/6158310767111411938) started by @anudeep-peela*