### PR TITLE
🎨 Palette: Enhance keyboard accessibility and screen reader context

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,6 +156,14 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label');
+                if (currentLabel) {
+                    if (isExpanded) {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace(/^Expand\s/, 'Collapse '));
+                    } else {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace(/^Collapse\s/, 'Expand '));
+                    }
+                }
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -109,8 +109,12 @@ a {
 .main-nav a.active {
   background: rgba(255, 255, 255, 0.7);
   color: var(--accent);
-  outline: none;
   box-shadow: 0 2px 8px rgba(18, 21, 26, 0.02), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.main-nav a:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .main-nav a.active {
@@ -253,8 +257,12 @@ p {
 
 .button:hover,
 .button:focus-visible {
-  outline: none;
   transform: translateY(-2px);
+}
+
+.button:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .button.primary:hover,
@@ -762,6 +770,11 @@ p {
   background: rgba(16, 42, 194, 0.1);
 }
 
+.case-expand-btn:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
 .case-card.expanded .case-expand-btn {
   transform: rotate(180deg);
   background: var(--accent);
@@ -959,11 +972,16 @@ p {
   transform: translateY(0);
 }
 
-.back-to-top:hover,
+.back-to-top:hover {
+  background: #fff;
+  color: var(--accent-dark);
+}
+
 .back-to-top:focus-visible {
   background: #fff;
   color: var(--accent-dark);
-  outline: none;
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .hidden {
@@ -1346,6 +1364,11 @@ p {
   background: rgba(18, 21, 26, 0.08);
   color: var(--accent);
   transform: scale(1.05);
+}
+
+.modal-close-btn:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .modal-close-btn:active {


### PR DESCRIPTION
💡 What: 
- Replaced `outline: none;` on `:focus-visible` with a standard 3px solid `--accent` focus ring with an offset for improved keyboard navigation visibility across interactive elements.
- Dynamically update the `aria-label` of the accordion toggle buttons ("Expand" vs "Collapse") when interacted with.

🎯 Why:
- Improves visual feedback for keyboard users navigating the site, making the interface more usable without a mouse.
- Enhances context for screen reader users by clearly indicating the state/action of the accordion buttons.

♿ Accessibility:
- Focus states are now clearly visible and consistent across navigation links, buttons, case expand toggles, and 'back to top' buttons.
- Expand/collapse actions are properly announced by screen readers.

---
*PR created automatically by Jules for task [8481594799812451758](https://jules.google.com/task/8481594799812451758) started by @anudeep-peela*