### PR TITLE
🎨 Palette: Dynamic ARIA labels for accordion buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,6 +156,15 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label');
+                if (currentLabel) {
+                    targetBtn.setAttribute(
+                        'aria-label',
+                        isExpanded
+                            ? currentLabel.replace(/^Expand/, 'Collapse')
+                            : currentLabel.replace(/^Collapse/, 'Expand')
+                    );
+                }
             }
         }
 

--- a/scroll.test.js
+++ b/scroll.test.js
@@ -116,10 +116,13 @@ async function runInteractionTests() {
   caseButtons[0].click();
   assert.strictEqual(caseButtons[0].getAttribute('aria-expanded'), 'true');
   assert.strictEqual(caseCards[0].querySelector('.case-body').getAttribute('aria-hidden'), 'false');
+  assert.ok(caseButtons[0].getAttribute('aria-label').startsWith('Collapse'));
 
   caseButtons[1].click();
   assert.strictEqual(caseButtons[0].getAttribute('aria-expanded'), 'false');
+  assert.ok(caseButtons[0].getAttribute('aria-label').startsWith('Expand'));
   assert.strictEqual(caseButtons[1].getAttribute('aria-expanded'), 'true');
+  assert.ok(caseButtons[1].getAttribute('aria-label').startsWith('Collapse'));
 
   const noteCard = document.querySelector('.article-card[data-essay]');
   noteCard.click();


### PR DESCRIPTION
💡 What: Added dynamic ARIA labels to the case card expansion buttons that toggle between 'Expand' and 'Collapse' based on the expanded state.
🎯 Why: Enhances accessibility for screen reader users by providing explicit context about the next available action, rather than relying solely on the `aria-expanded` state.
♿ Accessibility: Improves screen reader clarity for interactive elements with custom states.

---
*PR created automatically by Jules for task [1368385651531406288](https://jules.google.com/task/1368385651531406288) started by @anudeep-peela*