### PR TITLE
🎨 Palette: Dynamic ARIA label toggle for case cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,6 +156,13 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label');
+                if (currentLabel) {
+                    var newLabel = isExpanded
+                        ? currentLabel.replace('Expand', 'Collapse')
+                        : currentLabel.replace('Collapse', 'Expand');
+                    targetBtn.setAttribute('aria-label', newLabel);
+                }
             }
         }
 


### PR DESCRIPTION
🎨 Palette: Dynamic ARIA label toggle for case cards

💡 What: Automatically updates the `aria-label` of `.case-expand-btn` buttons to swap the words "Expand" and "Collapse" based on the component's state.
🎯 Why: Enhances accessibility by letting screen reader users know exactly what the next interaction will do, rather than having a static label.
♿ Accessibility: Combined with the existing `aria-expanded` toggle, this creates a fully robust, screen-reader friendly accordion experience.

---
*PR created automatically by Jules for task [6786991851227931907](https://jules.google.com/task/6786991851227931907) started by @anudeep-peela*