### PR TITLE
🎨 Palette: Improve keyboard focus styles and dynamic ARIA labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,6 +156,12 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label') || '';
+                if (isExpanded) {
+                    targetBtn.setAttribute('aria-label', currentLabel.replace(/^Expand/, 'Collapse'));
+                } else {
+                    targetBtn.setAttribute('aria-label', currentLabel.replace(/^Collapse/, 'Expand'));
+                }
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -113,6 +113,11 @@ a {
   box-shadow: 0 2px 8px rgba(18, 21, 26, 0.02), inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
+.main-nav a:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
 .main-nav a.active {
   background: var(--accent);
   color: #fff;
@@ -255,6 +260,11 @@ p {
 .button:focus-visible {
   outline: none;
   transform: translateY(-2px);
+}
+
+.button:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .button.primary:hover,
@@ -964,6 +974,11 @@ p {
   background: #fff;
   color: var(--accent-dark);
   outline: none;
+}
+
+.back-to-top:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .hidden {


### PR DESCRIPTION
💡 What: Added consistent keyboard focus outlines (`:focus-visible`) and dynamic `aria-label`s for the accordion expand buttons.
🎯 Why: To ensure keyboard-only users can visibly see where focus is and screen reader users hear accurate action verbs (Expand vs Collapse).
♿ Accessibility: Improves WCAG compliance for focus visibility (2.4.7) and meaningful sequence / aria attributes (4.1.2).

---
*PR created automatically by Jules for task [17204320161132180539](https://jules.google.com/task/17204320161132180539) started by @anudeep-peela*