### PR TITLE
🎨 Palette: Dynamic aria-labels for accordion buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -156,6 +156,14 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (targetBtn) {
                 targetBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                var currentLabel = targetBtn.getAttribute('aria-label');
+                if (currentLabel) {
+                    if (isExpanded) {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace(/^Expand/, 'Collapse'));
+                    } else {
+                        targetBtn.setAttribute('aria-label', currentLabel.replace(/^Collapse/, 'Expand'));
+                    }
+                }
             }
         }
 

--- a/scroll.test.js
+++ b/scroll.test.js
@@ -116,10 +116,13 @@ async function runInteractionTests() {
   caseButtons[0].click();
   assert.strictEqual(caseButtons[0].getAttribute('aria-expanded'), 'true');
   assert.strictEqual(caseCards[0].querySelector('.case-body').getAttribute('aria-hidden'), 'false');
+  assert.ok(caseButtons[0].getAttribute('aria-label').startsWith('Collapse'));
 
   caseButtons[1].click();
   assert.strictEqual(caseButtons[0].getAttribute('aria-expanded'), 'false');
   assert.strictEqual(caseButtons[1].getAttribute('aria-expanded'), 'true');
+  assert.ok(caseButtons[0].getAttribute('aria-label').startsWith('Expand'));
+  assert.ok(caseButtons[1].getAttribute('aria-label').startsWith('Collapse'));
 
   const noteCard = document.querySelector('.article-card[data-essay]');
   noteCard.click();


### PR DESCRIPTION
💡 **What:** Added dynamic updating of the `aria-label` for case study accordion buttons to toggle between "Expand..." and "Collapse..." based on state. Added associated test assertions to `scroll.test.js`.
🎯 **Why:** To improve accessibility for screen reader users by providing an accurate, actionable label that reflects the next available action (as noted in Palette's critical learnings).
♿ **Accessibility:** This directly enhances the screen reader experience when interacting with custom expand/collapse components by explicitly stating the current action context.

---
*PR created automatically by Jules for task [2528491037757827470](https://jules.google.com/task/2528491037757827470) started by @anudeep-peela*